### PR TITLE
Fixed TypeError when trying to build setup.py

### DIFF
--- a/version.py
+++ b/version.py
@@ -68,6 +68,7 @@ def readGitVersion():
         data, _ = proc.communicate()
         if proc.returncode:
             return None
+        data = data.decode('utf8')
         ver = data.splitlines()[0].strip()
     except Exception:
         return None


### PR DESCRIPTION
Fix the following exception when trying to build with python 3.7:
```
(venv) ➜ pip install -e .
Obtaining file:///Users/usr/Glencoe/omero-user-token
  Preparing metadata (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /Users/usr/Glencoe/omero-user-token/venv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/Users/usr/Glencoe/omero-user-token/setup.py'"'"'; __file__='"'"'/Users/usr/Glencoe/omero-user-token/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/x/x/T/pip-pip-egg-info-apckenjc
       cwd: /Users/usr/Glencoe/omero-user-token/
  Complete output (12 lines):
  version: release version (0.1.1') is invalid, will use it anyway
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/Users/usr/Glencoe/omero-user-token/setup.py", line 49, in <module>
      version=version.getVersion(),
    File "/Users/usr/Glencoe/omero-user-token/version.py", line 114, in getVersion
      version = readGitVersion() or release_version
    File "/Users/usr/Glencoe/omero-user-token/version.py", line 77, in readGitVersion
      m = re.search(_GIT_DESCRIPTION_RE, ver)
    File "/Users/usr/.pyenv/versions/3.7.10/lib/python3.7/re.py", line 185, in search
      return _compile(pattern, flags).search(string)
  TypeError: cannot use a string pattern on a bytes-like object
```