### PR TITLE
Updating Click Version Pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(name='omero-user-token',
       platforms='any',
       setup_requires=['flake8'],
       install_requires=[
-          'click==7.0',
+          'click>=7.0',
           'configparser==4.0.2',
           'omero-py>5.6',
       ],


### PR DESCRIPTION
Updated click pin to be `>= 7.0`. 

As far as I can tell there is no changes between `7.0` and the latest `8.1.3` that would break or affect `omero-user-token`. Current install is incompatible with some of Glencoe Software tools, eg error: 
```
flask 2.0.1 requires click>=7.1.2
celery 5.2.7 requires click<9.0,>=8.0.3
```