### PR TITLE
Add unit tests for omero_user_token retrieval APIs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,13 +31,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: python -mpip install -U wheel flake8 virtualenv
+        run: |
+          python -mpip install -U wheel pip
+          pip install -r requirements-dev.txt
       - name: Run tests
         run: |
             git fetch --prune --unshallow --tags --force
             git describe
             flake8
-            python setup.py build
+            python setup.py install
+            pytest -v
 
   # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
   publish-pypi:

--- a/omero_user_token/__init__.py
+++ b/omero_user_token/__init__.py
@@ -20,8 +20,10 @@ from omero.rtypes import unwrap
 
 
 def assert_and_get_token_dir():
-    home = os.path.expanduser('~')
-    token_dir = os.path.join(home, '.omero_user_token')
+    token_dir = os.getenv('OMERO_USER_TOKEN_DIR', default=None)
+    if token_dir is None:
+        home = os.path.expanduser('~')
+        token_dir = os.path.join(home, '.omero_user_token')
     if not os.path.exists(token_dir):
         os.makedirs(token_dir)
     os.chmod(token_dir, stat.S_IRWXU)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20221003/zeroc_ice-3.6.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
+https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20221003/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
+https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20221003/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
+https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp38-cp38-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.8"
+https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp39-cp39-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.9"
+https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp310-cp310-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.10"
+flake8
+pytest

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Glencoe Software, Inc. All rights reserved.
+#
+# This software is distributed under the terms described by the LICENSE.txt
+# file you can find at the root of the distribution bundle.  If the file is
+# missing please request a copy by contacting info@glencoesoftware.com
+
+
+from omero_user_token import assert_and_get_token_dir
+from omero_user_token import assert_and_get_token_path
+from omero_user_token import get_token
+from omero_user_token import getter
+from omero_user_token import login
+
+import omero
+import os
+import pytest
+import uuid
+
+
+class TestUserToken:
+
+    @pytest.fixture(autouse=True)
+    def set_up_token_dir(self, monkeypatch, tmpdir):
+        self.token_dir = str(tmpdir / ".omero_user_token")
+        monkeypatch.setenv("OMERO_USER_TOKEN_DIR", self.token_dir)
+        self.token_path = str(tmpdir / ".omero_user_token" / "token")
+
+    def write_token(self, token):
+        os.makedirs(self.token_dir)
+        with open(self.token_path, 'w') as f:
+            f.write(token)
+
+    def test_assert_and_get_token_dir(self):
+        token_dir = assert_and_get_token_dir()
+        assert token_dir == self.token_dir
+        assert os.path.exists(token_dir)
+        assert os.path.isdir(token_dir)
+
+    def test_assert_and_get_token_path(self):
+        token_path = assert_and_get_token_path()
+        assert token_path == self.token_path
+        assert os.path.exists(os.path.dirname(token_path))
+
+    def test_get_token(self):
+        token = "%s@localhost:4064" % uuid.uuid4()
+        self.write_token(token)
+        assert get_token() == token
+
+    def test_get_token_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            get_token()
+
+    def test_login(self):
+        token = "%s@localhost:4064" % uuid.uuid4()
+        self.write_token(token)
+        client = login(get_token())
+        assert isinstance(client, omero.clients.BaseClient)
+
+    @pytest.mark.parametrize("invalidtoken", (
+        "%s", "%s@", "%s@localhost"))
+    def test_login_invalid_token(self, invalidtoken):
+        token = invalidtoken % uuid.uuid4()
+        self.write_token(token)
+        with pytest.raises(ValueError):
+            login(get_token())
+
+    def test_getter(self, monkeypatch):
+        token = "%s@localhost:4064" % uuid.uuid4()
+        self.write_token(token)
+        monkeypatch.setattr(
+            omero.clients.BaseClient, "getSession", lambda x: True)
+        assert getter() == token
+
+    def test_getter_invalid_session(self):
+        token = "%s@localhost:4064" % uuid.uuid4()
+        self.write_token(token)
+        with pytest.raises(SystemExit):
+            getter()


### PR DESCRIPTION
Largely driven by #7, this adds a minimal set of unit tests covering `assert_and_get_token_dir`, `assert_and_get_token_path`, `get_token`, `login` and `getter` APIs under various scenarios

Includes:
-  a new envvar `OMERO_USER_TOKEN_DIR` is introduced to allow tests to use temporary directories
- a `requirements-dev.txt` including the pre-built Ice Python wheels for speeding up Linux/OSX CI builds