### PR TITLE
Report host for invalid tokens

### DIFF
--- a/omero_user_token/__init__.py
+++ b/omero_user_token/__init__.py
@@ -95,10 +95,11 @@ def getter():
     try:
         token = get_token()
         client = login(token)
+        host = client.getProperty("omero.host")
         try:
             client.getSession()
         except Exception:
-            sys.exit('ERROR: Token is invalid!')
+            sys.exit(f'ERROR: Token for {host} is invalid!')
         finally:
             client.closeSession()
         return token

--- a/omero_user_token/cli/omero_user_token.py
+++ b/omero_user_token/cli/omero_user_token.py
@@ -44,7 +44,7 @@ def cli():
 def _set(server, port, user, time_to_idle):
     password = getpass.getpass("Password: ")
     token = setter(server, port, user, password, time_to_idle)
-    print('Successfuly set token: %s' % token)
+    print('Successfully set token: %s' % token)
 
 
 @click.command()


### PR DESCRIPTION
An issue with the current `get` command is that if your token expires it's not immediately obvious which server that token was for.

To solve this I've modified the error message to include the server name.

Before:
```
> omero_user_token get
ERROR: Token is invalid!
```

After:
```
> omero_user_token get
ERROR: Token for my.omero.server is invalid!
```

Also fixed a typo in the setter message