### PR TITLE
Require Python 3.9 as the minimum version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,15 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
+          - '3.12'
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         include:
-          - python-version: '3.8'
+          - python-version: '3.10'
             os: macos-latest
-          - python-version: '3.8'
+          - python-version: '3.9'
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,10 @@
-https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20221003/zeroc_ice-3.6.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
-https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20221003/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
-https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20221003/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
-https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp38-cp38-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.8"
-https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp39-cp39-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.9"
-https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp310-cp310-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.10"
+https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
+https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
+https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.11"
+https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.12"
+https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp39-cp39-macosx_11_0_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.9"
+https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp310-cp310-macosx_11_0_universal2.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.10"
+https://github.com/glencoesoftware/zeroc-ice-py-win-x86_64/releases/download/20240325/zeroc_ice-3.6.5-cp39-cp39-win_amd64.whl; platform_system=="Windows" and python_version=="3.9"
 flake8
+setuptools
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def read(fname):
 
 
 setup(name='omero-user-token',
-      python_requires='>=3.6',
+      python_requires='>=3.9',
       version=version.getVersion(),
       description='OMERO user token management system',
       long_description=read('README.md'),
@@ -56,11 +56,10 @@ setup(name='omero-user-token',
           'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
           'Intended Audience :: Science/Research',
           'Intended Audience :: Developers',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10'
+          'Programming Language :: Python :: 3.11'
+          'Programming Language :: Python :: 3.12'
       ],
       keywords='',
       author='Glencoe Software, Inc.',


### PR DESCRIPTION
Follows the inclusion of #8.
The GitHub workflows were broken as several packages no longer install on EOL Python 3.8 and the OSX runners have been upgraded to arm64

The following changes are made to the packaging and workflows:

- require Python 3.9 as the minimum version
- update Linux wheels to include Python 3.11 and 3.12
- add Python 3.11 and 3.12 to testing matrix
- test on OS X / Python 3.10 to use the pre-built universal Ice Python wheel package
- remove bdist_wheel universal marker