### PR TITLE
Drop url wheels from project metadata

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,18 +12,25 @@ jobs:
       # Keep running so we can see if other tests pass
       fail-fast: false
       matrix:
-        python-version:
-          - '3.9'
-          - '3.10'
-          - '3.11'
-          - '3.12'
-        os:
-          - ubuntu-24.04
-        include:
+          include:
+          - python-version: '3.9'
+            os: ubuntu-24.04
+            ice: "https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl"
+          - python-version: '3.10'
+            os: ubuntu-24.04
+            ice: "https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl"
+          - python-version: '3.11'
+            os: ubuntu-24.04
+            ice: "https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl"
+          - python-version: '3.12'
+            os: ubuntu-24.04
+            ice: "https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl"
           - python-version: '3.10'
             os: macos-latest
+            ice: "https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp310-cp310-macosx_11_0_universal2.whl"
           - python-version: '3.9'
             os: windows-latest
+            ice: "https://github.com/glencoesoftware/zeroc-ice-py-win-x86_64/releases/download/20240325/zeroc_ice-3.6.5-cp39-cp39-win_amd64.whl"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +44,8 @@ jobs:
         run: python -m pip install build flake8
       - name: Run flake8
         run: flake8 ./omero_user_token
+      - name: Install zeroc-ice
+        run: python -m pip install ${{ matrix.ice }}
       - name: Install package
         run: python -m pip install .[dev]
       - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,15 +37,6 @@ omero-user-token = "omero_user_token.cli.omero_user_token:main"
 
 
 [project.optional-dependencies]
-dev = [
-    "pytest",
-    "zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl ; platform_system=='Linux' and python_version=='3.9'",
-    "zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl ; platform_system=='Linux' and python_version=='3.10'",
-    "zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl ; platform_system=='Linux' and python_version=='3.11'",
-    "zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl ; platform_system=='Linux' and python_version=='3.12'",
-    "zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp39-cp39-macosx_11_0_x86_64.whl ; platform_system=='Darwin' and python_version=='3.9'",
-    "zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp310-cp310-macosx_11_0_universal2.whl ; platform_system=='Darwin' and python_version=='3.10'",
-    "zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-win-x86_64/releases/download/20240325/zeroc_ice-3.6.5-cp39-cp39-win_amd64.whl ; platform_system=='Windows' and python_version=='3.9'"
-]
+dev = ["pytest"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Looks like pypi doesn't allow packages which point directly to dependency URLs, which is understandable. This solution is less clean but should be permitted by the index.